### PR TITLE
FIX: add missing build script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "nodemon server.js",
-    "start": "node server.js"
+    "start": "node server.js",
+    "build": "prisma generate"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## ✅ What

Added a `build` script to the `backend/package.json` file that runs `prisma generate`.

## 🤔 Why

This change allows developers to run Prisma's code generation step via `npm run build`, ensuring that Prisma client files are generated as part of the build process.

## 👩‍🔬 How to validate

1. Navigate to the `backend` directory.
2. Run `npm run build`.
3. Confirm that Prisma client files are generated in the appropriate `node_modules/.prisma/client` directory (or wherever your config defines).

## 🔖 Further reading

* [Github project task](link)