### PR TITLE
fix: ensure customerId is parsed as an integer in user update query

### DIFF
--- a/backend/Controllers/AdminControllers.js
+++ b/backend/Controllers/AdminControllers.js
@@ -750,7 +750,7 @@ const PromoteCustomerToAdmin = async (req, res) => {
 
     const updatedCustomerDetails = await prisma.users.update({
       where: {
-        id: customerId,
+        id: parseInt(customerId),
         email: email,
         role: 'CUSTOMER',
       },


### PR DESCRIPTION
## ✅ What

Fixes the `PromoteCustomerToAdmin` controller by ensuring `customerId` is parsed as an integer before being used in the `prisma.users.update` query.

## 🤔 Why

`customerId` was previously passed as a string, which could lead to Prisma query failures or unexpected behavior since the `id` field in the database expects an integer.

## 👩‍🔬 How to validate

1. Call the `PromoteCustomerToAdmin` endpoint with a valid `customerId` and email.
2. Ensure that the customer is successfully promoted to an admin without any errors.
3. Verify in the database that the role of the specified user has changed from `CUSTOMER` to `ADMIN`.
4. Run automated tests (if any) for this controller to confirm no regressions.

## 🔖 Further reading

- [Github project task](<link>)
